### PR TITLE
refactor: remove unnecessary logging from address validation and USPS…

### DIFF
--- a/app/routes/api.validate-address.tsx
+++ b/app/routes/api.validate-address.tsx
@@ -30,23 +30,6 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 
   // Regular validation flow
-  // Clone the request before reading it multiple times
-  const requestClone = request.clone();
-  try {
-    console.log('Request Body:', await requestClone.text());
-  } catch (error) {
-    console.log('Error reading request body as text');
-  }
-
-  try {
-    console.log('Request JSON:', await request.clone().json());
-  } catch (error) {
-    console.log('Error reading request body as JSON');
-  }
-
-  console.log('Request Headers:', request.headers.get("Content-Type"));
-  console.log('Request Headers:', request.headers.get("Accept"));
-
   try {
     // Authenticate the request using the session token
     await authenticate.public.checkout(request);

--- a/app/utils/usps.server.ts
+++ b/app/utils/usps.server.ts
@@ -159,8 +159,6 @@ export async function getUSPSToken(clientId: string, clientSecret: string): Prom
       throw new Error(`USPS API authentication failed: ${response.status} ${errorText}`);
     }
 
-    console.log('USPS token response status:', response);
-
     // Parse the JSON response
     const data = await response.json() as USPSTokenResponse;
 

--- a/extensions/address-validation/src/Checkout.tsx
+++ b/extensions/address-validation/src/Checkout.tsx
@@ -82,7 +82,6 @@ function Extension() {
     const { countryCode, city, zip, address1, address2, provinceCode } = shippingAddress;
     console.log('📋 ADDRESS DATA:', {address1, address2, city, provinceCode, zip, countryCode});
     const token = await sessionToken.get();
-    console.log('sessionToken.get()', token);
 
     const isUSA = countryCode === "US";
 


### PR DESCRIPTION
This pull request primarily focuses on cleaning up the code by removing unnecessary logging statements. The most important changes include the removal of console logs in various files.

Code cleanup:

* [`app/routes/api.validate-address.tsx`](diffhunk://#diff-bb5ecff8d77562a1503a26b98c39d23d94e4748d592438ffa5a08ec4428f9944L33-L49): Removed multiple console log statements that were logging the request body and headers.
* [`app/utils/usps.server.ts`](diffhunk://#diff-750df7fa8ddc62db649ab46dc9b514025681ba9a749c50e83988b6a2444d3d05L162-L163): Removed a console log statement that was logging the USPS token response status.
* [`extensions/address-validation/src/Checkout.tsx`](diffhunk://#diff-16ff57fb16315e17c59da7293b10563f6f79dbc0a8d142dc06adb486288dc663L85): Removed a console log statement that was logging the session token.