### PR TITLE
Add-EIP-to-EC2

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -81,7 +81,6 @@ jobs:
 
           # Create .env file with secrets directly in the deployment directory
           cat > $TEMP_DIR/$DEPLOY_DIR/.env <<EOL
-          DATABASE_PROVIDER=postgresql
           DATABASE_URL=${DATABASE_URL}
           SHOPIFY_API_KEY=${SHOPIFY_API_KEY}
           SHOPIFY_API_SECRET=${SHOPIFY_API_SECRET}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,6 @@ The application uses Prisma ORM with PostgreSQL in production:
 1. Uses SQLite for local development and PostgreSQL for production
 2. Database schema is defined in `prisma/schema.prisma`
 3. Database connection is configured via environment variables:
-   - `DATABASE_PROVIDER`: Set to "postgresql" for production
    - `DATABASE_URL`: Connection string to the PostgreSQL database
 
 ### Deployment Architecture
@@ -97,7 +96,6 @@ The infrastructure includes:
 The following environment variables are required:
 
 #### Database Connection
-- `DATABASE_PROVIDER`: Database provider (e.g., "postgresql")
 - `DATABASE_URL`: Database connection string
 
 #### Shopify Integration

--- a/development.env.example
+++ b/development.env.example
@@ -2,7 +2,6 @@
 # Copy this file to .env for local development
 
 # Database Configuration (SQLite for development)
-DATABASE_PROVIDER=sqlite
 DATABASE_URL=file:dev.sqlite
 
 # Shopify App Configuration

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,7 +9,7 @@ generator client {
 // enough when changing adapters.
 // See https://www.prisma.io/docs/orm/reference/prisma-schema-reference#string for more information
 datasource db {
-  provider = env("DATABASE_PROVIDER")
+  provider = "postgresql"
   url      = env("DATABASE_URL")
 }
 

--- a/production.env.example
+++ b/production.env.example
@@ -2,7 +2,6 @@
 # DO NOT commit this file with real values
 
 # Database Configuration (PostgreSQL for production)
-DATABASE_PROVIDER=postgresql
 DATABASE_URL=postgresql://user:password@your-rds-endpoint.region.rds.amazonaws.com:5432/addressvalidation
 
 # Shopify App Configuration

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -282,7 +282,6 @@ resource "aws_instance" "app_server" {
               
               # Create env file for the application
               cat > /app/.env <<EOL
-              DATABASE_PROVIDER=postgresql
               DATABASE_URL=postgresql://${var.db_username}:${var.db_password}@${aws_db_instance.app_db.endpoint}/${var.db_name}
               EOL
               EOF


### PR DESCRIPTION
This pull request removes the use of the `DATABASE_PROVIDER` environment variable across the codebase, simplifying database configuration. The database provider is now explicitly set to `postgresql` in the Prisma schema, and references to `DATABASE_PROVIDER` have been removed from environment files, documentation, and deployment scripts.

### Removal of `DATABASE_PROVIDER`:

* [`.github/workflows/deploy-app.yml`](diffhunk://#diff-7230a3559048fcc2ba14a726875d84cc74b726e7b8003611596cc2bd92ac5581L84): Removed the `DATABASE_PROVIDER` variable from the `.env` file creation process in deployment workflows.
* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL12-R12): Updated the `datasource` block to explicitly set the `provider` to `"postgresql"` instead of using the `DATABASE_PROVIDER` environment variable.
* [`terraform/production/main.tf`](diffhunk://#diff-935213383c94bc941559a01a806fc4f82dcf14634354acc0349acf00938c71faL285): Removed the `DATABASE_PROVIDER` variable from the environment file generation for the production server.

### Updates to environment files:

* [`development.env.example`](diffhunk://#diff-7f748d33d924cdd1701479285f46b6c92a167096f7cfc3db2b446e9c9cbff147L5): Removed the `DATABASE_PROVIDER=sqlite` line, as it is no longer required for local development.
* [`production.env.example`](diffhunk://#diff-2aaec2cfd503149ad2337eaebcad76ebe7a8cea0eadb82be38a55b1c1e3c70bfL5): Removed the `DATABASE_PROVIDER=postgresql` line, as it is no longer required for production.

### Documentation updates:

* [`CLAUDE.md`](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L45): Removed all references to the `DATABASE_PROVIDER` environment variable from the database configuration and deployment architecture sections. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L45) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L100)